### PR TITLE
Remove next_upgrade flag

### DIFF
--- a/src/prototypes/commonAdjustments.lua
+++ b/src/prototypes/commonAdjustments.lua
@@ -1,5 +1,6 @@
 local function commonAdjustments(factory)
     factory.minable = nil
+    factory.next_upgrade = nil
     factory.fast_replaceable_group = nil
     factory.dying_explosion = "big-explosion"
     factory.max_health = 1600


### PR DESCRIPTION
This was crashing me on Factorio 0.17.3, since the `next_upgrade` flag appears to have a lot of requirements that are already made `nil`. I presume that these should simply not be upgradable, and removed the flag from the prototypes.