### PR TITLE
fix crash when attempting to complain about recipe with no main result

### DIFF
--- a/src/scripts/recipeSetup.lua
+++ b/src/scripts/recipeSetup.lua
@@ -124,7 +124,7 @@ local function findSubgroup(recipe)
     product = product or recipe.main_product
 
     if product == nil then
-        log("No main product found " .. recipename .. serpent.dump(recipe))
+        log("No main product found " .. recipe.name .. serpent.dump(recipe))
         return
     end
 


### PR DESCRIPTION
Failed to load mod "WhistleStopFactories": __WhistleStopFactories__/data-final-fixes.lua:4: __WhistleStopFactories__/scripts/recipeSetup.lua:127: attempt to concatenate global 'recipename' (a nil value)
stack traceback:
	__WhistleStopFactories__/scripts/recipeSetup.lua:127: in function 'findSubgroup'
	__WhistleStopFactories__/scripts/recipeSetup.lua:211: in function 'recipeSetup'
	__WhistleStopFactories__/scripts/recipeSetup.lua:241: in main chunk
	[C]: in function 'require'
	__WhistleStopFactories__/data-final-fixes.lua:4: in main chunk
stack traceback:
	[C]: in function 'require'
	__WhistleStopFactories__/data-final-fixes.lua:4: in main chun